### PR TITLE
Add 15 minute plus frequency mode

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -28,7 +28,7 @@
         "basalt"
     ],
     "uuid": "187e3434-3d4f-4e33-9e5c-0239723121dc",
-    "versionLabel": "1.01",
+    "versionLabel": "1.1.2",
     "watchapp": {
         "watchface": false
     }

--- a/src/main.h
+++ b/src/main.h
@@ -6,6 +6,9 @@
 #define KEY_QUIET_TIME_START 4
 #define KEY_QUIET_TIME_END 5
 
+// buzz intervals
+#define BUZZ_INTERVAL_15_PLUS 115
+
 // buzz intensity
 #define BUZZ_DISABLED 0
 #define BUZZ_SHORT 1


### PR DESCRIPTION
## Summary
- add a 15 minute plus frequency mode that escalates the vibration count at each quarter hour while honoring the selected intensity
- update the settings menu and scheduling logic to support the new option and persist its selection
- bump the application version to 1.1.2

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce0844a678832eaa781dbf8141fa07